### PR TITLE
fix(#86): restore CategoryForecast including child categories

### DIFF
--- a/packages/Category/CategoryForecast/description.txt
+++ b/packages/Category/CategoryForecast/description.txt
@@ -2,12 +2,9 @@ Category Forecast Report Using Repeating Transactions
 
 This report will calculate the transactions for the current year in a given category and then use the remaining repeating transactions to forecast the total for the category at year's end.
 
-LIMITATIONS/KNOWN ISSUES:
-Does not include split transactions.
-Only works for an entire category, not individual subcategories.
-
 USAGE:
-Update category name in line 15 of the SQL.
+Update category ID in SQL (see comments in the file for instructions).
+As written, it will include all children of that category in the forecast, however if you don't want this behavior, there are instructions to just forecast a single category as well. 
 
 SIMPLE EXAMPLE: 
 

--- a/packages/Category/CategoryForecast/luacontent.lua
+++ b/packages/Category/CategoryForecast/luacontent.lua
@@ -1,9 +1,10 @@
     local total = 0;
     local forecast = 0;
     local period = 6;
-    local initialized = 0;
     local repeatcode = 0;
     local numrepeats = 0;
+	local categid = -99;
+	local categname = "";
 
     function is_leap_year(year)
         local ly = 0;
@@ -139,11 +140,17 @@
     end
 
     function handle_record(record)
-        if initialized == 0 then
-            total = record:get("BALANCE");
-            forecast= total;
-            initialized = 1;
-        end
+		-- BALANCE gets repeated if there are more than one recurring transaction with the same categid.
+		--    This if statement will only add BALANCE to the total and forecast the first time
+		if record:get("CATEGID") ~= categid then
+			categid = record:get("CATEGID");
+			total = total + record:get("BALANCE");
+			forecast= forecast + record:get("BALANCE");
+			-- very first time, get the title of the category for the HTML report
+		    if categname == "" then
+                categname = record:get("CATEGORY");
+            end		
+		end
         repeatcode = tonumber(record:get("REPEATS"));
         numrepeats = record:get("NUMOCCURRENCES");
         local amount = record:get("TRANSAMOUNT");
@@ -170,4 +177,5 @@
         local curDay = os.date('%d');
         result:set("Current_Total", total);
         result:set("Projected", forecast);
+		result:set("categname", categname);
     end

--- a/packages/Category/CategoryForecast/template.htt
+++ b/packages/Category/CategoryForecast/template.htt
@@ -7,7 +7,7 @@
 </head>
 <body>
     <div class="container">
-        <h3>Category Forecast Report (Bills)</h3>
+        <h3>Category Forecast Report (<TMPL_VAR categname>)</h3>
         <p><TMPL_VAR TODAY></p>
         <div class="row">
             <div class="col-xs-2"></div>
@@ -45,9 +45,22 @@
     </div>   
 </body>
 <script>
-    <!-- Format numbers -->
-        function currency(n) {n = parseFloat(n); return isNaN(n) ? 0 : n.toFixed(2);}
-        var elements= document.getElementsByClassName("money");
-        for (var i = 0; i < elements.length; i++) {elements[i].innerHTML = currency(elements[i].innerHTML);}
-</script>
+    <!-- Format double to base currency -->
+    function currency(n) {
+        n = parseFloat(n);
+        n =  isNaN(n) ? 0 : n.toFixed(2);
+        var out = n.toString().replace(".", "|");
+        out = out.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "<TMPL_VAR GROUP_SEPARATOR>");
+        out = out.replace("|", "<TMPL_VAR DECIMAL_POINT>");
+        return out;
+    }
+    var elements= document.getElementsByClassName("money");
+    for (var i = 0; i < elements.length; i++) {
+        var element = elements[i];
+        element.style.textAlign='right';
+        if (element.innerHTML.indexOf("-") > -1) {
+            element.style.color="#ff0000";
+        } 
+        element.innerHTML = '<TMPL_VAR PFX_SYMBOL>' + currency(element.innerHTML) +'<TMPL_VAR SFX_SYMBOL>';
+    }</script>
 </html>


### PR DESCRIPTION
Restores previous (db v16) behavior to include child categories when calculating the forecast.